### PR TITLE
bump: fix incorrect namespace for ProcessWebhookJob

### DIFF
--- a/src/ProcessSparkpostWebhookJob.php
+++ b/src/ProcessSparkpostWebhookJob.php
@@ -7,7 +7,7 @@ use Spatie\Mailcoach\Domain\Campaign\Events\WebhookCallProcessedEvent;
 use Spatie\Mailcoach\Domain\Shared\Models\Send;
 use Spatie\Mailcoach\Domain\Shared\Support\Config;
 use Spatie\WebhookClient\Models\WebhookCall;
-use Spatie\WebhookClient\ProcessWebhookJob;
+use Spatie\WebhookClient\Jobs\ProcessWebhookJob;
 
 class ProcessSparkpostWebhookJob extends ProcessWebhookJob
 {


### PR DESCRIPTION
Not sure this is a 5.6 Mailcoach change, but needed this change on our installation.